### PR TITLE
Enhance Prompt logic for Model update to 5-series

### DIFF
--- a/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
+++ b/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
@@ -39,4 +39,4 @@ Optional args:
 [CONVERSATION]
 {{ conversation }}
 
-Determine which function to call to proceed. Your output but be in JSON format.
+Determine which function to call to proceed. Your output must be in JSON format.

--- a/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
+++ b/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
@@ -38,3 +38,5 @@ Optional args:
 
 [CONVERSATION]
 {{ conversation }}
+
+Determine which function to call to proceed. Your output but be in JSON format.


### PR DESCRIPTION
Added a small piece to enhance the prompt logic for a stable toll calling results when shifting to 5-series model; Also proved to have no influence for previous 4-series model usage.